### PR TITLE
Feat: allow per channel and macro cooldown

### DIFF
--- a/src/main/kotlin/me/moeszyslak/polly/MainApp.kt
+++ b/src/main/kotlin/me/moeszyslak/polly/MainApp.kt
@@ -63,6 +63,7 @@ suspend fun main() {
             if (guildConfiguration != null) {
                 val staffRole = it.guild!!.getRole(guildConfiguration.staffRole.toSnowflake())
                 val loggingChannel = it.guild!!.getChannel(guildConfiguration.logChannel.toSnowflake())
+                val cooldown = guildConfiguration.channelCooldown
 
                 field {
 
@@ -70,6 +71,7 @@ suspend fun main() {
                     value = "```" +
                             "Staff Role: ${staffRole.name}\n" +
                             "Logging Channel: ${loggingChannel.name}\n" +
+                            "Channel Cooldown: $cooldown seconds\n" +
                             "```"
                 }
             }

--- a/src/main/kotlin/me/moeszyslak/polly/conversations/ConfigurationConversation.kt
+++ b/src/main/kotlin/me/moeszyslak/polly/conversations/ConfigurationConversation.kt
@@ -1,9 +1,7 @@
 package me.moeszyslak.polly.conversations
 
 import com.gitlab.kordlib.core.entity.Guild
-import me.jakejmattson.discordkt.api.arguments.ChannelArg
-import me.jakejmattson.discordkt.api.arguments.EveryArg
-import me.jakejmattson.discordkt.api.arguments.RoleArg
+import me.jakejmattson.discordkt.api.arguments.*
 import me.jakejmattson.discordkt.api.dsl.Conversation
 import me.jakejmattson.discordkt.api.dsl.conversation
 import me.moeszyslak.polly.data.Configuration
@@ -13,6 +11,7 @@ fun configurationConversation(guildId: GuildId, configuration: Configuration) = 
     val prefix = promptMessage(EveryArg, "Bot prefix:")
     val log = promptMessage(ChannelArg, "Log channel:")
     val staffRole = promptMessage(RoleArg, "Staff role:")
+    val cooldown = promptMessage(TimeArg, "Channel Macro cooldown:")
 
-    configuration.setup(guildId, log, prefix, staffRole)
+    configuration.setup(guildId, log, prefix, staffRole, cooldown)
 }

--- a/src/main/kotlin/me/moeszyslak/polly/data/Configuration.kt
+++ b/src/main/kotlin/me/moeszyslak/polly/data/Configuration.kt
@@ -14,13 +14,14 @@ data class Configuration(
     operator fun get(id: GuildId) = guildConfigurations[id]
     fun hasGuildConfig(guildId: GuildId) = guildConfigurations.containsKey(guildId)
 
-    fun setup(guildId: GuildId, logChannel: Channel, prefix: String, staffRole: Role) {
+    fun setup(guildId: GuildId, logChannel: Channel, prefix: String, staffRole: Role, cooldown: Double) {
         if (guildConfigurations[guildId] != null) return
 
         val newConfiguration = GuildConfiguration(
                 logChannel.id.longValue,
                 prefix,
                 staffRole.id.longValue,
+                cooldown,
                 mutableSetOf()
         )
 
@@ -33,5 +34,6 @@ data class GuildConfiguration(
         var logChannel: Long,
         var prefix: String,
         var staffRole: Long,
+        var channelCooldown: Double,
         var ignoredUsers: MutableSet<Long>
 )


### PR DESCRIPTION
The duration of time is configurable in setup and is per guild.

All of the channels have the same duration of cooldown per guild, and the cooldown is tracked individually for each macro per channel.