### PR TITLE
feat: add tracked macro functionality

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,8 @@ group = "me.moeszyslak"
 version = Versions.BOT
 
 plugins {
-    kotlin("jvm") version "1.5.21"
+    kotlin("jvm") version "1.6.0"
+    kotlin("plugin.serialization") version "1.6.0"
     id("com.github.johnrengelman.shadow") version "7.0.0"
 }
 

--- a/commands.md
+++ b/commands.md
@@ -6,13 +6,15 @@
 | [Argument]  | Argument is not required.      |
 
 ## Basics
-| Commands   | Arguments | Description                                                |
-| ---------- | --------- | ---------------------------------------------------------- |
-| Cooldown   | Time      | Set the cooldown between macro invokes                     |
-| LogChannel | Channel   | Set the channel where logs will be output.                 |
-| Prefix     | Prefix    | Set the prefix required for the bot to register a command. |
-| Setup      |           | Setup a guild to use Polly                                 |
-| StaffRole  | Role      | Set the role required to use this bot.                     |
+| Commands      | Arguments | Description                                                   |
+| ------------- | --------- | ------------------------------------------------------------- |
+| AlertChannel  | Channel   | Set the channel where alerts will be output.                  |
+| Cooldown      | Time      | Set the cooldown between macro invokes                        |
+| LogChannel    | Channel   | Set the channel where logs will be output.                    |
+| Prefix        | Prefix    | Set the prefix required for the bot to register a command.    |
+| Setup         |           | Setup a guild to use Polly                                    |
+| StaffRole     | Role      | Set the role required to use this bot.                        |
+| TrackedMacros | Enabled   | Toggle tracked macros (macros that post to the alert channel) |
 
 ## IgnoreList
 | Commands   | Arguments        | Description                            |
@@ -26,6 +28,7 @@
 | AddAlias        | Name, [Channel], Alias            | Add an alias to a macro                                                                                       |
 | AddChannelMacro | Name, Category, Channel, Contents | Adds a macro to a specific channel                                                                            |
 | AddMacro        | Name, Category, Contents          | Adds a macro (for all channels)                                                                               |
+| AddTrackedMacro | Name, Category, Contents          | Adds a tracked macro (for all channels)                                                                       |
 | EditCategory    | Name, [Channel], New Category     | Edits the category of a macro                                                                                 |
 | EditMacro       | Name, [Channel], Contents         | Edits the contents of a macro                                                                                 |
 | ListAllMacros   |                                   | Lists all macros available in the guild, grouped by channel.                                                  |
@@ -35,6 +38,8 @@
 | RemoveAlias     | Name, [Channel], Alias            | Remove an alias from a macro                                                                                  |
 | RemoveMacro     | Name, [Channel]                   | Removes a macro                                                                                               |
 | SearchMacros    | Text                              | Search the available macros available                                                                         |
+| Track           | Name, [Channel]                   | Converts an existing macro to a tracked (alert) macro                                                         |
+| Untrack         | Name, [Channel]                   | Removes tracking from an existing macro                                                                       |
 
 ## Utility
 | Commands | Arguments | Description          |

--- a/src/main/kotlin/me/moeszyslak/polly/MainApp.kt
+++ b/src/main/kotlin/me/moeszyslak/polly/MainApp.kt
@@ -1,12 +1,12 @@
 package me.moeszyslak.polly
 
-import dev.kord.common.kColor
+import dev.kord.common.entity.Snowflake
 import dev.kord.gateway.Intent
 import dev.kord.gateway.Intents
 import dev.kord.gateway.PrivilegedIntent
 import dev.kord.x.emoji.Emojis
-import me.jakejmattson.discordkt.api.dsl.bot
-import me.jakejmattson.discordkt.api.extensions.toSnowflake
+import me.jakejmattson.discordkt.dsl.bot
+import me.jakejmattson.discordkt.extensions.pfpUrl
 import me.moeszyslak.polly.data.Configuration
 import me.moeszyslak.polly.data.MacroStore
 import me.moeszyslak.polly.data.Permissions
@@ -22,6 +22,9 @@ suspend fun main() {
     require(token != null) { "Expected the bot token as an environment variable" }
 
     bot(token) {
+        val configuration = data("config/config.json") { Configuration() }
+        val macros = data("config/macros.json") { MacroStore() }
+
         prefix {
             val configuration = discord.getInjectionObjects(Configuration::class)
             guild?.let { configuration[it.id.value]?.prefix } ?: prefix
@@ -41,10 +44,10 @@ suspend fun main() {
         mentionEmbed {
             title = "Polly"
             description = "A simple, elegant macro bot"
-            color = it.discord.configuration.theme?.kColor
+            color = it.discord.configuration.theme
 
             thumbnail {
-                url = it.discord.kord.getSelf().avatar.url
+                url = it.discord.kord.getSelf().pfpUrl
             }
 
             field {
@@ -64,8 +67,8 @@ suspend fun main() {
             val guildConfiguration = configuration[it.guild!!.id.value]
 
             if (guildConfiguration != null) {
-                val staffRole = it.guild!!.getRole(guildConfiguration.staffRole.toSnowflake())
-                val loggingChannel = it.guild!!.getChannel(guildConfiguration.logChannel.toSnowflake())
+                val staffRole = it.guild!!.getRole(Snowflake(guildConfiguration.staffRole))
+                val loggingChannel = it.guild!!.getChannel(Snowflake(guildConfiguration.logChannel))
                 val cooldown = guildConfiguration.channelCooldown
 
                 field {

--- a/src/main/kotlin/me/moeszyslak/polly/commands/GuildConfiguration.kt
+++ b/src/main/kotlin/me/moeszyslak/polly/commands/GuildConfiguration.kt
@@ -1,9 +1,6 @@
 package me.moeszyslak.polly.commands
 
-import me.jakejmattson.discordkt.arguments.AnyArg
-import me.jakejmattson.discordkt.arguments.ChannelArg
-import me.jakejmattson.discordkt.arguments.RoleArg
-import me.jakejmattson.discordkt.arguments.TimeArg
+import me.jakejmattson.discordkt.arguments.*
 import me.jakejmattson.discordkt.commands.commands
 import me.moeszyslak.polly.conversations.configurationConversation
 import me.moeszyslak.polly.data.Configuration
@@ -61,10 +58,24 @@ fun guildConfigurationCommands(configuration: Configuration) = commands("Basics"
             val logChannel = args.first
             val config = configuration[guild.id.value] ?: return@execute
 
-            config.staffRole = logChannel.id.value
+            config.logChannel = logChannel.id.value
             configuration.save()
 
             respond("Log channel set to ${logChannel.name}")
+        }
+    }
+
+    command("AlertChannel") {
+        description = "Set the channel where alerts will be output."
+        requiredPermission = Permissions.STAFF
+        execute(ChannelArg) {
+            val alertChannel = args.first
+            val config = configuration[guild.id.value] ?: return@execute
+
+            config.alertChannel = alertChannel.id.value
+            configuration.save()
+
+            respond("Alert channel set to ${alertChannel.name}")
         }
     }
 
@@ -79,6 +90,20 @@ fun guildConfigurationCommands(configuration: Configuration) = commands("Basics"
             configuration.save()
 
             respond("Macro cooldown set to ${timeToString(cooldown.toLong() * 1000)}")
+        }
+    }
+
+    command("TrackedMacros") {
+        description = "Toggle tracked macros (macros that post to the alert channel)"
+        requiredPermission = Permissions.STAFF
+        execute(BooleanArg("Enabled", "enable", "disable")) {
+            val enabled = args.first
+            val config = configuration[guild.id.value] ?: return@execute
+
+            config.trackedMacrosEnabled = enabled
+            configuration.save()
+
+            respond("Logging of tracked macros is now ${if(enabled) "**enabled**" else "**disabled**"}")
         }
     }
 }

--- a/src/main/kotlin/me/moeszyslak/polly/commands/GuildConfiguration.kt
+++ b/src/main/kotlin/me/moeszyslak/polly/commands/GuildConfiguration.kt
@@ -1,10 +1,10 @@
 package me.moeszyslak.polly.commands
 
-import me.jakejmattson.discordkt.api.arguments.AnyArg
-import me.jakejmattson.discordkt.api.arguments.ChannelArg
-import me.jakejmattson.discordkt.api.arguments.RoleArg
-import me.jakejmattson.discordkt.api.arguments.TimeArg
-import me.jakejmattson.discordkt.api.commands.commands
+import me.jakejmattson.discordkt.arguments.AnyArg
+import me.jakejmattson.discordkt.arguments.ChannelArg
+import me.jakejmattson.discordkt.arguments.RoleArg
+import me.jakejmattson.discordkt.arguments.TimeArg
+import me.jakejmattson.discordkt.commands.commands
 import me.moeszyslak.polly.conversations.configurationConversation
 import me.moeszyslak.polly.data.Configuration
 import me.moeszyslak.polly.data.Permissions
@@ -12,7 +12,7 @@ import me.moeszyslak.polly.utilities.timeToString
 
 fun guildConfigurationCommands(configuration: Configuration) = commands("Basics") {
 
-    guildCommand("Setup") {
+    command("Setup") {
         description = "Setup a guild to use Polly"
         requiredPermission = Permissions.GUILD_OWNER
         execute {
@@ -26,7 +26,7 @@ fun guildConfigurationCommands(configuration: Configuration) = commands("Basics"
         }
     }
 
-    guildCommand("Prefix") {
+    command("Prefix") {
         description = "Set the prefix required for the bot to register a command."
         requiredPermission = Permissions.STAFF
         execute(AnyArg("Prefix")) {
@@ -40,7 +40,7 @@ fun guildConfigurationCommands(configuration: Configuration) = commands("Basics"
         }
     }
 
-    guildCommand("StaffRole") {
+    command("StaffRole") {
         description = "Set the role required to use this bot."
         requiredPermission = Permissions.STAFF
         execute(RoleArg) {
@@ -54,7 +54,7 @@ fun guildConfigurationCommands(configuration: Configuration) = commands("Basics"
         }
     }
 
-    guildCommand("LogChannel") {
+    command("LogChannel") {
         description = "Set the channel where logs will be output."
         requiredPermission = Permissions.STAFF
         execute(ChannelArg) {
@@ -68,7 +68,7 @@ fun guildConfigurationCommands(configuration: Configuration) = commands("Basics"
         }
     }
 
-    guildCommand("Cooldown") {
+    command("Cooldown") {
         description = "Set the cooldown between macro invokes"
         requiredPermission = Permissions.STAFF
         execute(TimeArg) {

--- a/src/main/kotlin/me/moeszyslak/polly/commands/IgnoreList.kt
+++ b/src/main/kotlin/me/moeszyslak/polly/commands/IgnoreList.kt
@@ -3,9 +3,9 @@ package me.moeszyslak.polly.commands
 import dev.kord.common.entity.Snowflake
 import dev.kord.common.kColor
 import dev.kord.core.entity.Member
-import me.jakejmattson.discordkt.api.arguments.ChoiceArg
-import me.jakejmattson.discordkt.api.arguments.UserArg
-import me.jakejmattson.discordkt.api.commands.commands
+import me.jakejmattson.discordkt.arguments.ChoiceArg
+import me.jakejmattson.discordkt.arguments.UserArg
+import me.jakejmattson.discordkt.commands.commands
 import me.moeszyslak.polly.data.Configuration
 import me.moeszyslak.polly.data.Permissions
 import java.awt.Color
@@ -18,7 +18,7 @@ fun Member.isIgnored(configuration: Configuration): Boolean {
 
 fun ignoreListCommands(configuration: Configuration) = commands("IgnoreList") {
 
-    guildCommand("IgnoreList") {
+    command("IgnoreList") {
         description = "Show ignore list."
         requiredPermission = Permissions.STAFF
         execute {
@@ -42,7 +42,7 @@ fun ignoreListCommands(configuration: Configuration) = commands("IgnoreList") {
         }
     }
 
-    guildCommand("Ignore") {
+    command("Ignore") {
         description = "Add/remove users from the ignore list."
         requiredPermission = Permissions.STAFF
         execute(

--- a/src/main/kotlin/me/moeszyslak/polly/commands/MacroCommands.kt
+++ b/src/main/kotlin/me/moeszyslak/polly/commands/MacroCommands.kt
@@ -69,6 +69,7 @@ fun macroCommands(macroService: MacroService) = commands("Macros") {
 
     command("Untrack") {
         description = "Removes tracking from an existing macro"
+        requiredPermission = Permissions.STAFF
         execute(AnyArg("Name"), ChannelArg<GuildMessageChannel>("Channel").optionalNullable()) {
             respond(macroService.toggleTrackingForExistingMacro(guild, args.first, args.second, false))
         }

--- a/src/main/kotlin/me/moeszyslak/polly/commands/MacroCommands.kt
+++ b/src/main/kotlin/me/moeszyslak/polly/commands/MacroCommands.kt
@@ -46,6 +46,34 @@ fun macroCommands(macroService: MacroService) = commands("Macros") {
         }
     }
 
+    command("AddTrackedMacro") {
+        description = "Adds a tracked macro (for all channels)"
+        requiredPermission = Permissions.STAFF
+
+        execute(AnyArg("Name"),
+            AnyArg("Category"),
+            EveryArg("Contents")) {
+            val (name, category, contents) = args
+
+            respond(macroService.addMacro(guild.id.value, name, category, null, contents, true))
+        }
+    }
+
+    command("Track") {
+        description = "Converts an existing macro to a tracked (alert) macro"
+        requiredPermission = Permissions.STAFF
+        execute(AnyArg("Name"), ChannelArg<GuildMessageChannel>("Channel").optionalNullable()) {
+            respond(macroService.toggleTrackingForExistingMacro(guild, args.first, args.second, true))
+        }
+    }
+
+    command("Untrack") {
+        description = "Removes tracking from an existing macro"
+        execute(AnyArg("Name"), ChannelArg<GuildMessageChannel>("Channel").optionalNullable()) {
+            respond(macroService.toggleTrackingForExistingMacro(guild, args.first, args.second, false))
+        }
+    }
+
     command("RemoveMacro") {
         description = "Removes a macro"
         requiredPermission = Permissions.STAFF

--- a/src/main/kotlin/me/moeszyslak/polly/commands/MacroCommands.kt
+++ b/src/main/kotlin/me/moeszyslak/polly/commands/MacroCommands.kt
@@ -1,16 +1,16 @@
 package me.moeszyslak.polly.commands
 
 import dev.kord.core.entity.channel.GuildMessageChannel
-import me.jakejmattson.discordkt.api.arguments.AnyArg
-import me.jakejmattson.discordkt.api.arguments.ChannelArg
-import me.jakejmattson.discordkt.api.arguments.ChoiceArg
-import me.jakejmattson.discordkt.api.arguments.EveryArg
-import me.jakejmattson.discordkt.api.commands.commands
+import me.jakejmattson.discordkt.arguments.AnyArg
+import me.jakejmattson.discordkt.arguments.ChannelArg
+import me.jakejmattson.discordkt.arguments.ChoiceArg
+import me.jakejmattson.discordkt.arguments.EveryArg
+import me.jakejmattson.discordkt.commands.commands
 import me.moeszyslak.polly.data.Permissions
 import me.moeszyslak.polly.services.MacroService
 
 fun macroCommands(macroService: MacroService) = commands("Macros") {
-    guildCommand("MacroInfo") {
+    command("MacroInfo") {
         description = "Get Information for a macro"
         requiredPermission = Permissions.NONE
 
@@ -19,7 +19,7 @@ fun macroCommands(macroService: MacroService) = commands("Macros") {
         }
     }
 
-    guildCommand("AddMacro") {
+    command("AddMacro") {
         description = "Adds a macro (for all channels)"
         requiredPermission = Permissions.STAFF
 
@@ -32,7 +32,7 @@ fun macroCommands(macroService: MacroService) = commands("Macros") {
         }
     }
 
-    guildCommand("AddChannelMacro") {
+    command("AddChannelMacro") {
         description = "Adds a macro to a specific channel"
         requiredPermission = Permissions.STAFF
 
@@ -46,7 +46,7 @@ fun macroCommands(macroService: MacroService) = commands("Macros") {
         }
     }
 
-    guildCommand("RemoveMacro") {
+    command("RemoveMacro") {
         description = "Removes a macro"
         requiredPermission = Permissions.STAFF
         execute(AnyArg("Name"), ChannelArg<GuildMessageChannel>("Channel").optionalNullable()) {
@@ -54,7 +54,7 @@ fun macroCommands(macroService: MacroService) = commands("Macros") {
         }
     }
 
-    guildCommand("EditMacro") {
+    command("EditMacro") {
         description = "Edits the contents of a macro"
         requiredPermission = Permissions.STAFF
         execute(AnyArg("Name"), ChannelArg<GuildMessageChannel>("Channel").optionalNullable(), EveryArg("Contents")) {
@@ -62,7 +62,7 @@ fun macroCommands(macroService: MacroService) = commands("Macros") {
         }
     }
 
-    guildCommand("EditCategory") {
+    command("EditCategory") {
         description = "Edits the category of a macro"
         requiredPermission = Permissions.STAFF
         execute(AnyArg("Name"), ChannelArg<GuildMessageChannel>("Channel").optionalNullable(), AnyArg("New Category")) {
@@ -70,7 +70,7 @@ fun macroCommands(macroService: MacroService) = commands("Macros") {
         }
     }
 
-    guildCommand("AddAlias") {
+    command("AddAlias") {
         description = "Add an alias to a macro"
         requiredPermission = Permissions.STAFF
         execute(AnyArg("Name"), ChannelArg<GuildMessageChannel>("Channel").optionalNullable(), AnyArg("Alias")) {
@@ -78,7 +78,7 @@ fun macroCommands(macroService: MacroService) = commands("Macros") {
         }
     }
 
-    guildCommand("RemoveAlias") {
+    command("RemoveAlias") {
         description = "Remove an alias from a macro"
         requiredPermission = Permissions.STAFF
         execute(AnyArg("Name"), ChannelArg<GuildMessageChannel>("Channel").optionalNullable(), AnyArg("Alias")) {
@@ -86,7 +86,7 @@ fun macroCommands(macroService: MacroService) = commands("Macros") {
         }
     }
 
-    guildCommand("ListMacros") {
+    command("ListMacros") {
         description = "Lists all macros available in the given channel. If no channel is specified, defaults to the current channel."
         requiredPermission = Permissions.NONE
         execute(ChannelArg<GuildMessageChannel>("Channel").optional() { it.channel as GuildMessageChannel }) {
@@ -94,7 +94,7 @@ fun macroCommands(macroService: MacroService) = commands("Macros") {
         }
     }
 
-    guildCommand("ListAllMacros") {
+    command("ListAllMacros") {
         description = "Lists all macros available in the guild, grouped by channel."
         requiredPermission = Permissions.NONE
         execute {
@@ -102,7 +102,7 @@ fun macroCommands(macroService: MacroService) = commands("Macros") {
         }
     }
 
-    guildCommand("MacroStats") {
+    command("MacroStats") {
         description = "Get statistics on most and least used macros"
         requiredPermission = Permissions.NONE
         execute(ChoiceArg("asc/desc", "asc", "desc").optional("desc")) {
@@ -113,7 +113,7 @@ fun macroCommands(macroService: MacroService) = commands("Macros") {
         }
     }
 
-    guildCommand("SearchMacros") {
+    command("SearchMacros") {
        description = "Search the available macros available"
         requiredPermission = Permissions.NONE
         execute(EveryArg) {

--- a/src/main/kotlin/me/moeszyslak/polly/conversations/ConfigurationConversation.kt
+++ b/src/main/kotlin/me/moeszyslak/polly/conversations/ConfigurationConversation.kt
@@ -1,7 +1,7 @@
 package me.moeszyslak.polly.conversations
 
-import me.jakejmattson.discordkt.api.arguments.*
-import me.jakejmattson.discordkt.api.conversations.conversation
+import me.jakejmattson.discordkt.arguments.*
+import me.jakejmattson.discordkt.conversations.conversation
 import me.moeszyslak.polly.data.Configuration
 import me.moeszyslak.polly.data.GuildId
 

--- a/src/main/kotlin/me/moeszyslak/polly/conversations/ConfigurationConversation.kt
+++ b/src/main/kotlin/me/moeszyslak/polly/conversations/ConfigurationConversation.kt
@@ -8,8 +8,9 @@ import me.moeszyslak.polly.data.GuildId
 fun configurationConversation(guildId: GuildId, configuration: Configuration) = conversation {
     val prefix = prompt(EveryArg, "Bot prefix:")
     val log = prompt(ChannelArg, "Log channel:")
+    val alert = prompt(ChannelArg, "Alert channel:")
     val staffRole = prompt(RoleArg, "Staff role:")
     val cooldown = prompt(TimeArg, "Channel Macro cooldown:")
 
-    configuration.setup(guildId, log, prefix, staffRole, cooldown)
+    configuration.setup(guildId, log, alert, prefix, staffRole, cooldown)
 }

--- a/src/main/kotlin/me/moeszyslak/polly/data/Configuration.kt
+++ b/src/main/kotlin/me/moeszyslak/polly/data/Configuration.kt
@@ -15,15 +15,17 @@ data class Configuration(
     operator fun get(id: GuildId) = guildConfigurations[id]
     fun hasGuildConfig(guildId: GuildId) = guildConfigurations.containsKey(guildId)
 
-    fun setup(guildId: GuildId, logChannel: Channel, prefix: String, staffRole: Role, cooldown: Double) {
+    fun setup(guildId: GuildId, logChannel: Channel, alertChannel: Channel, prefix: String, staffRole: Role, cooldown: Double) {
         if (guildConfigurations[guildId] != null) return
 
         val newConfiguration = GuildConfiguration(
-                logChannel.id.value,
-                prefix,
-                staffRole.id.value,
-                cooldown,
-                mutableSetOf()
+            logChannel.id.value,
+            alertChannel.id.value,
+            true,
+            prefix,
+            staffRole.id.value,
+            cooldown,
+            mutableSetOf()
         )
 
         guildConfigurations[guildId] = newConfiguration
@@ -34,6 +36,8 @@ data class Configuration(
 @Serializable
 data class GuildConfiguration(
         var logChannel: ULong,
+        var alertChannel: ULong,
+        var trackedMacrosEnabled: Boolean,
         var prefix: String,
         var staffRole: ULong,
         var channelCooldown: Double,

--- a/src/main/kotlin/me/moeszyslak/polly/data/Configuration.kt
+++ b/src/main/kotlin/me/moeszyslak/polly/data/Configuration.kt
@@ -2,13 +2,15 @@ package me.moeszyslak.polly.data
 
 import dev.kord.core.entity.Role
 import dev.kord.core.entity.channel.Channel
-import me.jakejmattson.discordkt.api.dsl.Data
+import kotlinx.serialization.Serializable
+import me.jakejmattson.discordkt.dsl.Data
 
-typealias GuildId = Long
+typealias GuildId = ULong
 
+@Serializable
 data class Configuration(
         val botOwner: Long = 345541952500006912,
-        val guildConfigurations: MutableMap<GuildId, GuildConfiguration> = mutableMapOf()) : Data("config/config.json") {
+        val guildConfigurations: MutableMap<GuildId, GuildConfiguration> = mutableMapOf()) : Data() {
 
     operator fun get(id: GuildId) = guildConfigurations[id]
     fun hasGuildConfig(guildId: GuildId) = guildConfigurations.containsKey(guildId)
@@ -29,10 +31,11 @@ data class Configuration(
     }
 }
 
+@Serializable
 data class GuildConfiguration(
-        var logChannel: Long,
+        var logChannel: ULong,
         var prefix: String,
-        var staffRole: Long,
+        var staffRole: ULong,
         var channelCooldown: Double,
-        var ignoredUsers: MutableSet<Long>
+        var ignoredUsers: MutableSet<ULong>
 )

--- a/src/main/kotlin/me/moeszyslak/polly/data/MacroStore.kt
+++ b/src/main/kotlin/me/moeszyslak/polly/data/MacroStore.kt
@@ -1,10 +1,12 @@
 package me.moeszyslak.polly.data
 
 import dev.kord.core.entity.channel.GuildMessageChannel
-import me.jakejmattson.discordkt.api.dsl.Data
+import kotlinx.serialization.Serializable
+import me.jakejmattson.discordkt.dsl.Data
 
+@Serializable
 data class MacroStore(
-        val macros: MutableMap<GuildId, MutableMap<String, Macro>> = mutableMapOf()) : Data("config/macros.json", killIfGenerated = false) {
+        val macros: MutableMap<GuildId, MutableMap<String, Macro>> = mutableMapOf()) : Data() {
     @Transient
     var aliases: MutableMap<GuildId, Map<String, String>> = mutableMapOf()
 
@@ -50,6 +52,7 @@ data class MacroStore(
     }
 }
 
+@Serializable
 data class Macro(
         val name: String,
         var aliases: MutableList<String> = mutableListOf(),

--- a/src/main/kotlin/me/moeszyslak/polly/data/MacroStore.kt
+++ b/src/main/kotlin/me/moeszyslak/polly/data/MacroStore.kt
@@ -59,6 +59,7 @@ data class Macro(
         var contents: String,
         val channel: String?,
         var category: String,
+        var tracked: Boolean = false,
         var uses: Int = 0
 ) {
     fun channel() = channel ?: ""
@@ -72,6 +73,6 @@ data class Macro(
                     .joinToString(" | ")
 }
 
-fun newMacro(name: String, contents: String, channel: String, category: String): Macro {
-    return Macro(name, mutableListOf(), contents, channel, category)
+fun newMacro(name: String, contents: String, channel: String, category: String, tracked: Boolean = false): Macro {
+    return Macro(name, mutableListOf(), contents, channel, category, tracked)
 }

--- a/src/main/kotlin/me/moeszyslak/polly/data/Permissions.kt
+++ b/src/main/kotlin/me/moeszyslak/polly/data/Permissions.kt
@@ -1,14 +1,14 @@
 package me.moeszyslak.polly.data
 
 import dev.kord.core.any
-import me.jakejmattson.discordkt.api.dsl.PermissionContext
-import me.jakejmattson.discordkt.api.dsl.PermissionSet
+import me.jakejmattson.discordkt.dsl.PermissionContext
+import me.jakejmattson.discordkt.dsl.PermissionSet
 
 @Suppress("unused")
 enum class Permissions : PermissionSet {
     BOT_OWNER {
         override suspend fun hasPermission(context: PermissionContext) =
-            context.discord.getInjectionObjects<Configuration>().botOwner == context.user.id.value
+            context.discord.getInjectionObjects<Configuration>().botOwner == context.user.id.value.toLong()
     },
     GUILD_OWNER {
         override suspend fun hasPermission(context: PermissionContext) =

--- a/src/main/kotlin/me/moeszyslak/polly/preconditions/IgnoreListPrecondition.kt
+++ b/src/main/kotlin/me/moeszyslak/polly/preconditions/IgnoreListPrecondition.kt
@@ -1,6 +1,6 @@
 package me.moeszyslak.polly.preconditions
 
-import me.jakejmattson.discordkt.api.dsl.*
+import me.jakejmattson.discordkt.dsl.*
 import me.moeszyslak.polly.commands.isIgnored
 import me.moeszyslak.polly.data.Configuration
 

--- a/src/main/kotlin/me/moeszyslak/polly/preconditions/SetupPrecondition.kt
+++ b/src/main/kotlin/me/moeszyslak/polly/preconditions/SetupPrecondition.kt
@@ -1,7 +1,7 @@
 package me.moeszyslak.polly.preconditions
 
-import me.jakejmattson.discordkt.api.commands.Command
-import me.jakejmattson.discordkt.api.dsl.*
+import me.jakejmattson.discordkt.commands.Command
+import me.jakejmattson.discordkt.dsl.*
 import me.moeszyslak.polly.data.Configuration
 
 fun setupPrecondition(configuration: Configuration) = precondition {

--- a/src/main/kotlin/me/moeszyslak/polly/services/MacroService.kt
+++ b/src/main/kotlin/me/moeszyslak/polly/services/MacroService.kt
@@ -1,7 +1,6 @@
 package me.moeszyslak.polly.services
 
 import dev.kord.common.entity.Snowflake
-import dev.kord.common.kColor
 import dev.kord.core.behavior.channel.MessageChannelBehavior
 import dev.kord.core.behavior.getChannelOf
 import dev.kord.core.entity.Guild
@@ -11,13 +10,12 @@ import dev.kord.x.emoji.Emojis
 import dev.kord.x.emoji.toReaction
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import me.jakejmattson.discordkt.api.Discord
-import me.jakejmattson.discordkt.api.annotations.Service
-import me.jakejmattson.discordkt.api.commands.CommandEvent
-import me.jakejmattson.discordkt.api.commands.GuildCommandEvent
-import me.jakejmattson.discordkt.api.dsl.listeners
-import me.jakejmattson.discordkt.api.extensions.toSnowflake
-import me.jakejmattson.discordkt.api.extensions.toSnowflakeOrNull
+import me.jakejmattson.discordkt.Discord
+import me.jakejmattson.discordkt.annotations.Service
+import me.jakejmattson.discordkt.commands.CommandEvent
+import me.jakejmattson.discordkt.commands.GuildCommandEvent
+import me.jakejmattson.discordkt.dsl.listeners
+import me.jakejmattson.discordkt.extensions.toSnowflakeOrNull
 import me.moeszyslak.polly.commands.isIgnored
 import me.moeszyslak.polly.data.*
 import me.xdrop.fuzzywuzzy.FuzzySearch
@@ -39,7 +37,7 @@ class MacroService(private val store: MacroStore, private val discord: Discord) 
 
         event.respond {
             title = "Macro - $name"
-            color = discord.configuration.theme?.kColor
+            color = discord.configuration.theme
             description = "```${parent.contents}```"
             field {
                 this.name = "Macro Name"
@@ -207,7 +205,7 @@ class MacroService(private val store: MacroStore, private val discord: Discord) 
             chunks.map {
                 page {
                     title = "Macros available in ${channel.name}"
-                    color = discord.configuration.theme?.kColor
+                    color = discord.configuration.theme
 
                     if (it.isNotEmpty()) {
                         it.map { (category, macros) ->
@@ -239,7 +237,7 @@ class MacroService(private val store: MacroStore, private val discord: Discord) 
             chunks.map {
                 page {
                     title = "All available macros"
-                    color = event.discord.configuration.theme?.kColor
+                    color = event.discord.configuration.theme
 
                     if (it.isNotEmpty()) {
                         it.map { (channel, macros) ->
@@ -277,7 +275,7 @@ class MacroService(private val store: MacroStore, private val discord: Discord) 
             chunks.map {
                 page {
                     title = if (asc) "Least used macros" else "Top Used Macros"
-                    color = event.discord.configuration.theme?.kColor
+                    color = event.discord.configuration.theme
                     if (it.isNotEmpty()) {
                         it.map { (channel, macros) ->
                             field {
@@ -312,7 +310,7 @@ class MacroService(private val store: MacroStore, private val discord: Discord) 
 
         event.respond {
             title = "Search Results - '$query'"
-            color = event.discord.configuration.theme?.kColor
+            color = event.discord.configuration.theme
 
             field {
                 name = "Top Results - By names and aliases"
@@ -405,7 +403,7 @@ fun macroListener(macroService: MacroService, configuration: Configuration) = li
 
         val logChannelId = configuration[guildId]?.logChannel ?: return@on
 
-        guild.getChannelOf<GuildMessageChannel>(logChannelId.toSnowflake())
+        guild.getChannelOf<GuildMessageChannel>(Snowflake(logChannelId))
                 .createMessage("${member.username} :: ${member.id.value} " +
                         "invoked $macroName in ${message.channel.mention}")
     }

--- a/src/main/kotlin/me/moeszyslak/polly/services/StatisticsService.kt
+++ b/src/main/kotlin/me/moeszyslak/polly/services/StatisticsService.kt
@@ -1,7 +1,7 @@
 package me.moeszyslak.polly.services
 
-import me.jakejmattson.discordkt.api.Discord
-import me.jakejmattson.discordkt.api.annotations.Service
+import me.jakejmattson.discordkt.Discord
+import me.jakejmattson.discordkt.annotations.Service
 import me.moeszyslak.polly.data.Configuration
 import me.moeszyslak.polly.utilities.timeToString
 import java.util.*


### PR DESCRIPTION
# feat: add tracked macro functionality

Add the ability for macros to become `tracked` and post to an alert channel to notify staff when they are invoked.

- Updated to latest DiscordKt snapshot.
- Added tracking functionality and update the configuration to include a flag to enable / disable notifications and commands to add tracked macros and update existing macros to become tracked.